### PR TITLE
Fixing background flicker in iOS Chrome

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -26,7 +26,7 @@ $color-text-secondary: $lightBlue;
 :root {
   --default-bg-color: #{$white};
   --section-alt-bg-color: #{$grayLight};
-  --hero-bg-color: #{$white};
+  --hero-bg-color: #{$grayLight};
   --hero-overlay-opacity: 0;
   --hero-heading-color: 0;
   --heading-color: #{$grayDark};

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -162,7 +162,9 @@ p {
 
 .header {
   position: relative;
-  background: var(--hero-bg-color) url('../images/bg-hero-winter.jpg') no-repeat center center;
+  background-color: var(--hero-bg-color);
+  background-image: url('../images/bg-hero-winter.jpg');
+  background-repeat: no-repeat;
   background-size: cover;
   text-align: center;
   color: var(--hero-heading-color);

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -165,6 +165,7 @@ p {
   background-color: var(--hero-bg-color);
   background-image: url('../images/bg-hero-winter.jpg');
   background-repeat: no-repeat;
+  background-position: center center;
   background-size: cover;
   text-align: center;
   color: var(--hero-heading-color);


### PR DESCRIPTION
Apparently, mixing CSS custom properties in the background shorthand doesn't work well. Meh, all fixed now.